### PR TITLE
Allow setting custom prompt text for status bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ main.js
 data.json
 
 obsidian.d.ts
+
+.DS_Store

--- a/main.ts
+++ b/main.ts
@@ -3,6 +3,17 @@ import { EditorSelection, Notice, App, MarkdownView, Plugin, PluginSettingTab, S
 
 declare const CodeMirror: any;
 
+const enum vimStatus {
+  normal = 'normal',
+  insert = 'insert',
+  visual = 'visual',
+  replace = 'replace',
+}
+type VimStatusPrompt = string;
+type VimStatusPromptMap = {
+  [status in vimStatus]: VimStatusPrompt;
+};
+
 interface Settings {
 	vimrcFileName: string,
 	displayChord: boolean,
@@ -10,6 +21,7 @@ interface Settings {
 	fixedNormalModeLayout: boolean,
 	capturedKeyboardMap: Record<string, string>,
 	supportJsCommands?: boolean
+  vimStatusPromptMap: VimStatusPromptMap;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -18,14 +30,13 @@ const DEFAULT_SETTINGS: Settings = {
 	displayVimMode: false,
 	fixedNormalModeLayout: false,
 	capturedKeyboardMap: {},
-	supportJsCommands: false
-}
-
-const enum vimStatus {
-	normal = "🟢",
-	insert = "🟠",
-	replace = "🔴",
-	visual = "🟡"
+	supportJsCommands: false,
+  vimStatusPromptMap: {
+    normal: '🟢',
+    insert: '🟠',
+    visual: '🟡',
+    replace: '🔴',
+  },
 }
 
 // NOTE: to future maintainers, please make sure all mapping commands are included in this array.
@@ -147,7 +158,9 @@ export default class VimrcPlugin extends Plugin {
 			this.isInsertMode = false;
 			this.currentVimStatus = vimStatus.normal;
 			if (this.settings.displayVimMode)
-				this.vimStatusBar?.setText(this.currentVimStatus);
+        this.vimStatusBar?.setText(
+          this.settings.vimStatusPromptMap[this.currentVimStatus]
+        );
 
 			cmEditor.off('vim-mode-change', this.logVimModeChange);
 			cmEditor.on('vim-mode-change', this.logVimModeChange);
@@ -217,7 +230,9 @@ export default class VimrcPlugin extends Plugin {
 				break;
 		}
 		if (this.settings.displayVimMode)
-			this.vimStatusBar?.setText(this.currentVimStatus);
+      this.vimStatusBar?.setText(
+        this.settings.vimStatusPromptMap[this.currentVimStatus]
+      );
 	}
 
 	onunload() {
@@ -583,7 +598,9 @@ export default class VimrcPlugin extends Plugin {
 	prepareVimModeDisplay() {
 		if (this.settings.displayVimMode) {
 			this.vimStatusBar = this.addStatusBarItem() // Add status bar item
-			this.vimStatusBar.setText(vimStatus.normal) // Init the vimStatusBar with normal mode
+      this.vimStatusBar.setText(
+        this.settings.vimStatusPromptMap[vimStatus.normal]
+      ); // Init the vimStatusBar with normal mode
 		}
 	}
 
@@ -744,5 +761,65 @@ class SettingsTab extends PluginSettingTab {
 					this.plugin.saveSettings();
 				})
 			});
+
+    new Setting(containerEl)
+      .setName('Normal mode prompt')
+      .setDesc('Set the status prompt text for normal mode.')
+      .addText((text) => {
+        text.setPlaceholder('Default: 🟢');
+        text.setValue(
+          this.plugin.settings.vimStatusPromptMap.normal ||
+            DEFAULT_SETTINGS.vimStatusPromptMap.normal
+        );
+        text.onChange((value) => {
+          this.plugin.settings.vimStatusPromptMap.normal = value;
+          this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Insert mode prompt')
+      .setDesc('Set the status prompt text for insert mode.')
+      .addText((text) => {
+        text.setPlaceholder('Default: 🟠');
+        text.setValue(
+          this.plugin.settings.vimStatusPromptMap.insert ||
+            DEFAULT_SETTINGS.vimStatusPromptMap.insert
+        );
+        text.onChange((value) => {
+          this.plugin.settings.vimStatusPromptMap.insert = value;
+          this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Visual mode prompt')
+      .setDesc('Set the status prompt text for visual mode.')
+      .addText((text) => {
+        text.setPlaceholder('Default: 🟡');
+        text.setValue(
+          this.plugin.settings.vimStatusPromptMap.visual ||
+            DEFAULT_SETTINGS.vimStatusPromptMap.visual
+        );
+        text.onChange((value) => {
+          this.plugin.settings.vimStatusPromptMap.visual = value;
+          this.plugin.saveSettings();
+        });
+      });
+
+    new Setting(containerEl)
+      .setName('Replace mode prompt')
+      .setDesc('Set the status prompt text for replace mode.')
+      .addText((text) => {
+        text.setPlaceholder('Default: 🔴');
+        text.setValue(
+          this.plugin.settings.vimStatusPromptMap.replace ||
+            DEFAULT_SETTINGS.vimStatusPromptMap.replace
+        );
+        text.onChange((value) => {
+          this.plugin.settings.vimStatusPromptMap.replace = value;
+          this.plugin.saveSettings();
+        });
+      });
 	}
 }


### PR DESCRIPTION
- Add .DS_Store to .gitignore
- Add custom prompt text settings for status bar

**Settings Page**
<img width="702" alt="Screen Shot 2023-03-27 at 14 46 19" src="https://user-images.githubusercontent.com/11176415/228075395-982b600c-1787-4e65-a3bf-e8d5f28ae54a.png">

**Status Bar**
<img width="105" alt="Screen Shot 2023-03-27 at 14 46 27" src="https://user-images.githubusercontent.com/11176415/228075422-2d4287fe-0bc8-4ddb-ae76-a0fbb892b687.png">
<img width="123" alt="Screen Shot 2023-03-27 at 14 47 06" src="https://user-images.githubusercontent.com/11176415/228075424-fe8288ec-d55e-43e1-918c-84e277b46c46.png">
<img width="109" alt="Screen Shot 2023-03-27 at 14 47 15" src="https://user-images.githubusercontent.com/11176415/228075426-93bb2e76-b0a0-4a0d-8b5c-babfddd68a3d.png">
<img width="116" alt="Screen Shot 2023-03-27 at 14 47 23" src="https://user-images.githubusercontent.com/11176415/228075427-7eff1948-1bfc-40a3-835f-63932b854d48.png">
