### PR TITLE
Add corresponding CSS class when changing status bar

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -39,6 +39,13 @@ const DEFAULT_SETTINGS: Settings = {
   },
 }
 
+const vimStatusPromptClassNameMap = {
+  normal: 'plugin-obsidian-vimrc-support-prompt-normal',
+  insert: 'plugin-obsidian-vimrc-support-prompt-insert',
+  visual: 'plugin-obsidian-vimrc-support-prompt-visual',
+  replace: 'plugin-obsidian-vimrc-support-prompt-replace',
+}
+
 // NOTE: to future maintainers, please make sure all mapping commands are included in this array.
 const mappingCommands: String[] = [
 	"map",
@@ -66,9 +73,23 @@ export default class VimrcPlugin extends Plugin {
 	private vimChordStatusBar: HTMLElement = null;
 	private vimStatusBar: HTMLElement = null;
 	private currentVimStatus: vimStatus = vimStatus.normal;
+  private currentVimStatusClassName: string = 
+    vimStatusPromptClassNameMap[vimStatus.normal];
 	private customVimKeybinds: { [name: string]: boolean } = {};
 	private currentSelection: [EditorSelection] = null;
 	private isInsertMode: boolean = false;
+
+  updateVimStatusBar() {
+    this.vimStatusBar?.setText(
+      this.settings.vimStatusPromptMap[this.currentVimStatus]
+    );
+    this.vimStatusBar?.classList.replace(
+      this.currentVimStatusClassName,
+      vimStatusPromptClassNameMap[this.currentVimStatus]
+    );
+    this.currentVimStatusClassName = 
+      vimStatusPromptClassNameMap[this.currentVimStatus];
+  }
 
 	async captureKeyboardLayout() {
 		// This is experimental API and it might break at some point:
@@ -158,10 +179,7 @@ export default class VimrcPlugin extends Plugin {
 			this.isInsertMode = false;
 			this.currentVimStatus = vimStatus.normal;
 			if (this.settings.displayVimMode)
-        this.vimStatusBar?.setText(
-          this.settings.vimStatusPromptMap[this.currentVimStatus]
-        );
-
+        this.updateVimStatusBar();
 			cmEditor.off('vim-mode-change', this.logVimModeChange);
 			cmEditor.on('vim-mode-change', this.logVimModeChange);
 
@@ -230,9 +248,7 @@ export default class VimrcPlugin extends Plugin {
 				break;
 		}
 		if (this.settings.displayVimMode)
-      this.vimStatusBar?.setText(
-        this.settings.vimStatusPromptMap[this.currentVimStatus]
-      );
+      this.updateVimStatusBar();
 	}
 
 	onunload() {
@@ -601,6 +617,9 @@ export default class VimrcPlugin extends Plugin {
       this.vimStatusBar.setText(
         this.settings.vimStatusPromptMap[vimStatus.normal]
       ); // Init the vimStatusBar with normal mode
+      this.vimStatusBar?.addClass(
+        vimStatusPromptClassNameMap[vimStatus.normal]
+      ); // Add the initial class name for normal mode
 		}
 	}
 


### PR DESCRIPTION
Adding CSS classes will allow people to further customize the styles of their status bar display :)

**Current Class Names**
| Mode | Class Name |
| --- | --- |
| normal | `plugin-obsidian-vimrc-support-prompt-normal` |
| insert | `plugin-obsidian-vimrc-support-prompt-insert` |
| visual | `plugin-obsidian-vimrc-support-prompt-visual` |
| replace | `plugin-obsidian-vimrc-support-prompt-replace` |

**Demo Usage**
```css
.plugin-obsidian-vimrc-support-prompt-normal {
    color: red;
}
.plugin-obsidian-vimrc-support-prompt-insert {
    color: blue;
}
```

And... TADA!

<img width="121" alt="Screen Shot 2023-03-27 at 15 20 21" src="https://user-images.githubusercontent.com/11176415/228079782-550203a7-d9d5-42ca-b051-1844bbc41667.png">
<img width="110" alt="Screen Shot 2023-03-27 at 15 20 15" src="https://user-images.githubusercontent.com/11176415/228079851-4116062a-e58e-4e63-a922-c56d0ac0c4ee.png">