### PR TITLE
Fix: use default values when setting values are empty strings

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -793,7 +793,8 @@ class SettingsTab extends PluginSettingTab {
 						DEFAULT_SETTINGS.vimStatusPromptMap.normal
 				);
 				text.onChange((value) => {
-					this.plugin.settings.vimStatusPromptMap.normal = value;
+					this.plugin.settings.vimStatusPromptMap.normal = value ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.normal;
 					this.plugin.saveSettings();
 				});
 			});
@@ -808,7 +809,9 @@ class SettingsTab extends PluginSettingTab {
 						DEFAULT_SETTINGS.vimStatusPromptMap.insert
 				);
 				text.onChange((value) => {
-					this.plugin.settings.vimStatusPromptMap.insert = value;
+					this.plugin.settings.vimStatusPromptMap.insert = value ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.insert;
+					console.log(this.plugin.settings.vimStatusPromptMap);
 					this.plugin.saveSettings();
 				});
 			});
@@ -823,7 +826,8 @@ class SettingsTab extends PluginSettingTab {
 						DEFAULT_SETTINGS.vimStatusPromptMap.visual
 				);
 				text.onChange((value) => {
-					this.plugin.settings.vimStatusPromptMap.visual = value;
+					this.plugin.settings.vimStatusPromptMap.visual = value ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.visual;
 					this.plugin.saveSettings();
 				});
 			});
@@ -838,7 +842,8 @@ class SettingsTab extends PluginSettingTab {
 						DEFAULT_SETTINGS.vimStatusPromptMap.replace
 				);
 				text.onChange((value) => {
-					this.plugin.settings.vimStatusPromptMap.replace = value;
+					this.plugin.settings.vimStatusPromptMap.replace = value ||
+						DEFAULT_SETTINGS.vimStatusPromptMap.replace;
 					this.plugin.saveSettings();
 				});
 			});


### PR DESCRIPTION
Now it works correctly: when the setting values are left blank, we use the default values instead.

**Empty Values on Settings Page**
<img width="690" alt="Screen Shot 2023-03-27 at 16 27 52" src="https://user-images.githubusercontent.com/11176415/228089335-33b6004b-ceb2-46ce-9bd8-a70d7a13ca76.png">

**Status Bar**
<img width="58" alt="Screen Shot 2023-03-27 at 16 28 00" src="https://user-images.githubusercontent.com/11176415/228089309-6da94309-ad56-4c00-befe-3259d68c7bb4.png">
