### PR TITLE
Add option for updating CSS class names to status bar as well

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -22,6 +22,7 @@ interface Settings {
 	capturedKeyboardMap: Record<string, string>,
 	supportJsCommands?: boolean
 	vimStatusPromptMap: VimStatusPromptMap;
+	vimModeStatusBarCSSClass: boolean;
 }
 
 const DEFAULT_SETTINGS: Settings = {
@@ -37,6 +38,7 @@ const DEFAULT_SETTINGS: Settings = {
 		visual: '🟡',
 		replace: '🔴',
 	},
+	vimModeStatusBarCSSClass: false,
 }
 
 const vimStatusPromptClassNameMap = {
@@ -83,6 +85,12 @@ export default class VimrcPlugin extends Plugin {
 		this.vimStatusBar?.setText(
 			this.settings.vimStatusPromptMap[this.currentVimStatus]
 		);
+		if (this.settings.vimModeStatusBarCSSClass) {
+			document.querySelector('div.status-bar')?.classList.replace(
+				this.currentVimStatusClassName,
+				vimStatusPromptClassNameMap[this.currentVimStatus]
+			);
+		}
 		this.vimStatusBar?.classList.replace(
 			this.currentVimStatusClassName,
 			vimStatusPromptClassNameMap[this.currentVimStatus]
@@ -617,6 +625,11 @@ export default class VimrcPlugin extends Plugin {
 			this.vimStatusBar.setText(
 				this.settings.vimStatusPromptMap[vimStatus.normal]
 			); // Init the vimStatusBar with normal mode
+			if (this.settings.vimModeStatusBarCSSClass) {
+				document.querySelector('div.status-bar')?.addClass(
+					vimStatusPromptClassNameMap[vimStatus.normal]
+				);
+			}
 			this.vimStatusBar?.addClass(
 				vimStatusPromptClassNameMap[vimStatus.normal]
 			); // Add the initial class name for normal mode
@@ -782,6 +795,23 @@ class SettingsTab extends PluginSettingTab {
 			});
 
 		containerEl.createEl('hr');
+
+		new Setting(containerEl)
+			.setName('Add Vim mode class to status bar')
+			.setDesc(
+				'Also add corresponding CSS class to status bar when Vim mode changes. ' +
+				'This allows powerline-ish styling on the whole status bar (requires restart).'
+			)
+			.addToggle(toggle => {
+				toggle.setValue(
+					this.plugin.settings.vimModeStatusBarCSSClass ??
+					DEFAULT_SETTINGS.vimModeStatusBarCSSClass
+				);
+				toggle.onChange(value => {
+					this.plugin.settings.vimModeStatusBarCSSClass = value;
+					this.plugin.saveSettings();
+				})
+			});
 
 		new Setting(containerEl)
 			.setName('Normal mode prompt')


### PR DESCRIPTION
If the option is set to true, the corresponding CSS classes will also be added to the `div.status-bar` element. This allows custom CSS on the whole status bar such as some powerline-ish stylings.

### Demo
**Settings Page**
<img width="1027" alt="Screen Shot 2023-03-27 at 21 02 40" src="https://user-images.githubusercontent.com/11176415/228125041-f00243ad-f290-4eb8-9506-0535dbe59398.png">

**Custom Status Bar**
Applying the one theme colors.

<img width="1466" alt="Screen Shot 2023-03-27 at 21 03 03" src="https://user-images.githubusercontent.com/11176415/228125089-bfd40171-d9ed-49f5-8e07-b217d69c3ead.png">
<img width="1470" alt="Screen Shot 2023-03-27 at 21 03 21" src="https://user-images.githubusercontent.com/11176415/228125133-bb0c555b-4d1d-4e5d-8ac5-7d207099206d.png">
<img width="1470" alt="Screen Shot 2023-03-27 at 21 11 36" src="https://user-images.githubusercontent.com/11176415/228126086-810229cd-29d1-4e57-944c-1d7d3993a30e.png">
<img width="1470" alt="Screen Shot 2023-03-27 at 21 11 56" src="https://user-images.githubusercontent.com/11176415/228126131-b1c7fedb-da80-46bc-a2d6-dd21a601ed22.png">